### PR TITLE
MemoryView: Add read_short() functions

### DIFF
--- a/memaccess/__init__.py
+++ b/memaccess/__init__.py
@@ -129,6 +129,28 @@ class MemoryView:
         """
         return self._read_and_convert('c', address)[0]
 
+    def read_short(self, address):
+        """
+        Reads a short (2 bytes) from memory.
+
+        :param address:
+            Memory address where to read from.
+        :return:
+            Short value at given address.
+        """
+        return self._read_and_convert('<h', address)[0]
+
+    def read_unsigned_short(self, address):
+        """
+        Reads an unsigned short (2 bytes) from memory.
+
+        :param address:
+            Memory address where to read from.
+        :return:
+            Unsigned short value at given address.
+        """
+        return self._read_and_convert('<H', address)[0]
+
     def read_float(self, address):
         """
         Reads a float (4 bytes) from memory.

--- a/tests/native/main.c
+++ b/tests/native/main.c
@@ -3,6 +3,7 @@
 void main() {
     char char_value = 55;
     short short_value = 12041;
+    unsigned ushort_value = 54310;
     int int_value = -988324;
     unsigned int uint_value = 2134;
 
@@ -13,6 +14,7 @@ void main() {
 
     printf("char: %i at %p\n", char_value, &char_value);
     printf("short: %i at %p\n", short_value, &short_value);
+    printf("unsigned short: %i at %p\n", ushort_value, &ushort_value);
     printf("int: %i at %p\n", int_value, &int_value);
     printf("unsigned int: %i at %p\n", uint_value, &uint_value);
 

--- a/tests/test_MemoryView.py
+++ b/tests/test_MemoryView.py
@@ -117,6 +117,28 @@ def test_read_char(testprocess):
         assert view.read_char(address) == value
 
 
+def test_read_short(testprocess):
+    rgx = r'short: (-?\d+) at ((?:0x)?[0-9A-Fa-f]+)'
+    match = match_list(rgx, testprocess.lines)
+
+    value = int(match.group(1))
+    address = int(match.group(2), 16)
+
+    with MemoryView(testprocess.pid) as view:
+        assert view.read_short(address) == value
+
+
+def test_read_unsigned_short(testprocess):
+    rgx = r'unsigned short: (\d+) at ((?:0x)?[0-9A-Fa-f]+)'
+    match = match_list(rgx, testprocess.lines)
+
+    value = int(match.group(1))
+    address = int(match.group(2), 16)
+
+    with MemoryView(testprocess.pid) as view:
+        assert view.read_unsigned_short(address) == value
+
+
 def test_read_float(testprocess):
     rgx = r'float: (-?\d+(?:\.\d+)?) at ((?:0x)?[0-9A-Fa-f]+)'
     match = match_list(rgx, testprocess.lines)


### PR DESCRIPTION
Reads a short value (2 bytes). Also adds the read function for the
unsigned version.

Closes https://github.com/Makman2/memaccess/issues/16